### PR TITLE
Added optional repeat parameter to sendCommand

### DIFF
--- a/src/SomfyRemote.cpp
+++ b/src/SomfyRemote.cpp
@@ -10,12 +10,12 @@ void SomfyRemote::setup() {
 	digitalWrite(emitterPin, LOW);
 }
 
-void SomfyRemote::sendCommand(Command command) {
+void SomfyRemote::sendCommand(Command command, int repeat) {
 	const uint16_t rollingCode = rollingCodeStorage->nextCode();
 	byte frame[7];
 	buildFrame(frame, command, rollingCode);
 	sendFrame(frame, 2);
-	for (int i = 0; i < 4; i++) {
+	for (int i = 0; i < repeat; i++) {
 		sendFrame(frame, 7);
 	}
 }

--- a/src/SomfyRemote.h
+++ b/src/SomfyRemote.h
@@ -32,7 +32,14 @@ private:
 public:
 	SomfyRemote(byte emitterPin, uint32_t remote, RollingCodeStorage *rollingCodeStorage);
 	void setup();
-	void sendCommand(Command command);
+	/**
+	 * Send a command with this SomfyRemote.
+	 *
+	 * @param command the command to send
+	 * @param repeat the number how often the command should be repeated, default 4. Should
+	 * 				 only be used when simulating holding a button.
+	 */
+	void sendCommand(Command command, int repeat = 4);
 };
 
 Command getSomfyCommand(const String &string);


### PR DESCRIPTION
Allows to configure command repeat, which can be used to simulate long button presses by increasing the repeat number.