### PR TITLE
Add rolling code parameter to sendCommand method

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Currently, there are two implementations of the storage available:
 
 Most [examples](examples/) use the EEPROM implementation. See the [ESP32-NVS](examples/ESP32-NVS/ESP32-NVS.ino) example for NVS.
 
+Eventually you can pass NULL into the constructor of the SomfyRemote class in place of *rollingCodeStorage* and use external rolling code keeping logic. 
+If you are not using any story, then you have to use `sendCommand` call with the third parameter, which is the rolling code.
+
 #### Available commands
 
 | Name    | Description                                     | HEX code |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Currently, there are two implementations of the storage available:
 Most [examples](examples/) use the EEPROM implementation. See the [ESP32-NVS](examples/ESP32-NVS/ESP32-NVS.ino) example for NVS.
 
 Eventually you can pass NULL into the constructor of the SomfyRemote class in place of *rollingCodeStorage* and use external rolling code keeping logic. 
-If you are not using any story, then you have to use `sendCommand` call with the third parameter, which is the rolling code.
+If you are not using any storage, then you have to use `sendCommand` call with the third parameter, which is the rolling code.
 
 #### Available commands
 

--- a/src/SomfyRemote.cpp
+++ b/src/SomfyRemote.cpp
@@ -12,6 +12,10 @@ void SomfyRemote::setup() {
 
 void SomfyRemote::sendCommand(Command command, int repeat) {
 	const uint16_t rollingCode = rollingCodeStorage->nextCode();
+	sendCommand(command, repeat, rollingCode);
+}
+
+void SomfyRemote::sendCommand(Command command, int repeat, uint16_t rollingCode) {
 	byte frame[7];
 	buildFrame(frame, command, rollingCode);
 	sendFrame(frame, 2);

--- a/src/SomfyRemote.h
+++ b/src/SomfyRemote.h
@@ -40,6 +40,16 @@ public:
 	 * 				 only be used when simulating holding a button.
 	 */
 	void sendCommand(Command command, int repeat = 4);
+	
+	/**
+	 * Send a command with this SomfyRemote using a specific rolling code.
+	 *
+	 * @param command the command to send
+	 * @param repeat the number how often the command should be repeated, default 4. Should
+	 * 				 only be used when simulating holding a button.
+	 * @param rollingCode the rolling code to use, default 0. Should only be used with external storage.
+	 */
+	void sendCommand(Command command, int repeat = 4, uint16_t rollingCode = 0);
 };
 
 Command getSomfyCommand(const String &string);


### PR DESCRIPTION
Hi,
I have added rolling code to the _sendCommand_ method to allow external storage of rolling codes.

I had a problem with NVS on ESP32C3 and decided to keep the rolling codes "offloaded". This approach allows users to use this library on bridge type of devices where there is no need to keep state of the controlled shutters.