### PR TITLE
Added sendCommandWithCode to enable use of custom rollingCode storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Currently, there are two implementations of the storage available:
 
 Most [examples](examples/) use the EEPROM implementation. See the [ESP32-NVS](examples/ESP32-NVS/ESP32-NVS.ino) example for NVS.
 
+Eventually you can pass NULL into the constructor of the SomfyRemote class in place of *rollingCodeStorage* and use external rolling code keeping logic. 
+If you are not using any storage, then you have to use `sendCommandWithCode` method instead of `sendCommand`.
+
 #### Available commands
 
 | Name    | Description                                     | HEX code |

--- a/src/SomfyRemote.cpp
+++ b/src/SomfyRemote.cpp
@@ -12,6 +12,10 @@ void SomfyRemote::setup() {
 
 void SomfyRemote::sendCommand(Command command, int repeat) {
 	const uint16_t rollingCode = rollingCodeStorage->nextCode();
+	sendCommandWithCode(command, repeat, rollingCode);
+}
+
+void SomfyRemote::sendCommandWithCode(Command command, uint16_t rollingCode, int repeat) {
 	byte frame[7];
 	buildFrame(frame, command, rollingCode);
 	sendFrame(frame, 2);

--- a/src/SomfyRemote.h
+++ b/src/SomfyRemote.h
@@ -40,6 +40,15 @@ public:
 	 * 				 only be used when simulating holding a button.
 	 */
 	void sendCommand(Command command, int repeat = 4);
+	/**
+	 * Send a command with this SomfyRemote.
+	 *
+	 * @param command the command to send
+	 * @param rollingCode the rolling code to use. Should only be used with external storage.
+	 * @param repeat the number how often the command should be repeated, default 4. Should
+	 * 				 only be used when simulating holding a button.
+	 */
+	void sendCommandWithCode(Command command, uint16_t rollingCode, int repeat = 4);
 };
 
 Command getSomfyCommand(const String &string);


### PR DESCRIPTION
Hi,
I'm following up on my previous PR ([#28](https://github.com/Legion2/Somfy_Remote_Lib/pull/28))

I have added `sendCommandWithCode` method to allow external storage of rolling codes.

I had a problem with NVS on ESP32C3 and decided to keep the rolling codes "offloaded". This approach allows users to use this library on bridge type of devices where there is no need to keep state of the controlled shutters.
